### PR TITLE
Custom number of shots and the fix to the path to nwq_qasm executable

### DIFF
--- a/qiskit/ghz.py
+++ b/qiskit/ghz.py
@@ -27,7 +27,7 @@ def cx_chain(qc,n):
 
 
 
-qc = QuantumCircuit(n_qubits, n_qubits)
+qc = QuantumCircuit(n_qubits)
 qc.h(0)
 cx_chain(qc,n_qubits)
 
@@ -50,10 +50,20 @@ svsim = nwqsim.backends['nwqsim']
 
 #print (qc.qasm())
 
+# default number of shots: 1024
+print("Default number of shots: 1024")
 job2 = svsim.run(qc)
 result2 = job2.result()
 counts2 = result2.get_counts(qc)
 print (counts2)
 print (result2.get_statevector(qc))
 
+# custom number of shots
+print("\nCustom number of shots: 5000")
+job3 = svsim.run(qc, shots=5000)
+result3 = job3.result()
+counts3 = result3.get_counts(qc)
+print (counts3)
+print (result3.get_statevector(qc))
+print ("Are two statevectors the same?", np.allclose(result2.get_statevector(qc), result3.get_statevector(qc)))
 

--- a/qiskit/setup.py
+++ b/qiskit/setup.py
@@ -93,5 +93,6 @@ setup(
     cmdclass={
         'build': NWQSimSimulatorBuild,
     },
-    distclass=BinaryDistribution
+    distclass=BinaryDistribution,
+    zip_safe=False
 )


### PR DESCRIPTION
In the original code, custom options in run() was bugged due to reversed parameters in hasattr() and custom number of shots was not working (always be 1024 despite how result dict shows) because the shot number was never in the cmd command.

Also, the package could not find the nwq_qasm executable previously. The path is also fixed.

ghz.py is modified to illustrate the custom options avalible.