### PR TITLE
Fidelity computation for comparing ideal and noisy simulations

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -1,7 +1,7 @@
 {
     "PRINT_SIM_TRACE": false,
     "ENABLE_FUSION": true,
-    "ENABLE_NOISE": true,
+    "ENABLE_NOISE": false,
     "ENABLE_TENSOR_CORE": false,
     "DEVICE_CONFIG_PATH": "../data/device/",
     "DEVICE_CONFIG_FILE": "dummy_ibmq15"

--- a/default_config.json
+++ b/default_config.json
@@ -1,7 +1,7 @@
 {
     "PRINT_SIM_TRACE": false,
     "ENABLE_FUSION": true,
-    "ENABLE_NOISE": false,
+    "ENABLE_NOISE": true,
     "ENABLE_TENSOR_CORE": false,
     "DEVICE_CONFIG_PATH": "../data/device/",
     "DEVICE_CONFIG_FILE": "dummy_ibmq15"

--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -222,7 +222,7 @@ This guide provides detailed instructions on how to execute the compiled program
 
 **Example Usage:** To run the qasm frontend from the `build` directory with a specific backend, a total number of shots, and a simulation method, use the following command: 
 
-```
+```bash
 ./qasm/nwq_qasm -backend <name> -shots <value> -sim <method> -q <path/to/qasm>
 ```
 
@@ -230,6 +230,11 @@ Replace `<name>`, `<value>`, `<method>`, and `<path/to/qasm>` with your desired 
 
 Please ensure that you replace `/qasm/nwq_qasm` with the actual name of your compiled executable file if not using the qasm frontend.
 
+To compute the fidelity, add the `-fidelity` flag (with an optional device JSON path):
+
+```bash
+./qasm/nwq_qasm -backend <name> -shots <value> -sim <method> -q <path/to/qasm> -fidelity -device <path/to/device_json>
+```
 
 ### Running on Frontier HPC
 

--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -194,6 +194,8 @@ This guide provides detailed instructions on how to execute the compiled program
 
 - `-a`: Runs all testing benchmarks. 
 
+- `device`: Sets the path to a device configuration JSON file for density matrix simulation. Note that this overwrites the file specified in `default_config.json`.
+
 - `-backend list`: Lists all the available backends. The list of available backends are:
   - CPU
   - OpenMP
@@ -210,8 +212,13 @@ This guide provides detailed instructions on how to execute the compiled program
 - `-basis`: Activates the program to run benchmark circuits using only basis gates.
 
 - `-sim <method>`: Sets the simulation method. There are two available options:
-  - `sv`: Stochastic Vector simulation.
-  - `dm`: Density Matrix simulation. Please note, when running with `dm`, the given circuit can only contain IBM basis gates and 2-qubit gates that are included in the device configuration file specified in the default_configuration.json file.
+  - `sv`: Statevector simulation.
+  - `dm`: Density Matrix simulation. Please note, when running with `dm`, the given circuit can only contain IBM basis gates and 2-qubit gates that are included in the device configuration file specified in the default_config.json file.
+
+- `-fidelity`: Calculates the fidelity resulting from quantum noise channels. NOTES: 
+  - This will run **both** the Statevector and Density Matrix simulators, so the given circuit can only contain IBM basis gates and 2-qubit gates that are included in the device configuration file specified in the default_config.json file or passed with `-device`. 
+  - Make sure that default_config.json has `enable_noise: true`, otherwise the fidelity will always be 1 (useful for debugging)
+  - If running with `-backend NVGPU_MPI`, the Statevector simulator will only run on the root node, while the Density Matrix simulator will run on all nodes.
 
 **Example Usage:** To run the qasm frontend from the `build` directory with a specific backend, a total number of shots, and a simulation method, use the following command: 
 
@@ -222,6 +229,7 @@ This guide provides detailed instructions on how to execute the compiled program
 Replace `<name>`, `<value>`, `<method>`, and `<path/to/qasm>` with your desired backend name, number of shots, and simulation method respectively.
 
 Please ensure that you replace `/qasm/nwq_qasm` with the actual name of your compiled executable file if not using the qasm frontend.
+
 
 ### Running on Frontier HPC
 

--- a/include/circuit.hpp
+++ b/include/circuit.hpp
@@ -25,7 +25,7 @@ namespace NWQSim
         Circuit(IdxType _n_qubits) : n_qubits(_n_qubits)
         {
             // Implementation of constructor
-            gates = std::make_shared<std::vector<Gate>>();
+            gates = std::make_shared<std::vector<Gate> >();
         }
         ~Circuit(){};
 
@@ -40,7 +40,7 @@ namespace NWQSim
         }
         void set_gates(std::vector<Gate> new_gates)
         {
-            gates = std::make_shared<std::vector<Gate>>(new_gates);
+            gates = std::make_shared<std::vector<Gate> >(new_gates);
         }
         void set_num_qubits(IdxType _n_qubits)
         {

--- a/include/circuit_pass/fusion.hpp
+++ b/include/circuit_pass/fusion.hpp
@@ -27,22 +27,19 @@
 #include "../private/gate_factory/sv_gates.hpp"
 #include "../private/gate_factory/dm_gates.hpp"
 
-#define vec_dim_1q(sim_type) (sim_type == SV ? 2 : 4)
-#define vec_dim_2q(sim_type) (sim_type == SV ? 4 : 16)
-#define vec_length_1q(sim_type) (sim_type == SV ? 4 : 16)
-#define vec_length_2q(sim_type) (sim_type == SV ? 16 : 256)
+#define vec_dim_1q(sim_type) (sim_type == SimType::SV ? 2 : 4)
+#define vec_dim_2q(sim_type) (sim_type == SimType::SV ? 4 : 16)
+#define vec_length_1q(sim_type) (sim_type == SimType::SV ? 4 : 16)
+#define vec_length_2q(sim_type) (sim_type == SimType::SV ? 16 : 256)
 
 namespace NWQSim
 {
-    enum SimType
-    {
-        SV,
-        DM
-    };
 
+
+    inline 
     enum OP get_op(IdxType n_qubits, SimType sim_type)
     {
-        if (sim_type == SV)
+        if (sim_type == SimType::SV)
         {
             return n_qubits == 1 ? OP::C1 : OP::C2;
         }
@@ -104,7 +101,7 @@ namespace NWQSim
 
         GateType SWAP(SWAP_SV);
 
-        if (sim_type == DM)
+        if (sim_type == SimType::DM)
             kron(SWAP_SV, SWAP_SV, SWAP, 4); // create SWAP superop for DM
 
         GateType tmp_g(get_op(2, sim_type), -1, -1);
@@ -118,7 +115,7 @@ namespace NWQSim
     {
         GateType gI(get_op(1, sim_type), ctrl, -1);
 
-        if (sim_type == SV)
+        if (sim_type == SimType::SV)
             gI.gm_real[0] = gI.gm_real[3] = 1; // set I for SV
         else
             gI.gm_real[0] = gI.gm_real[5] = gI.gm_real[10] = gI.gm_real[15] = 1; // set I for DM
@@ -131,7 +128,7 @@ namespace NWQSim
     {
         GateType gI(get_op(1, sim_type), qubit, -1);
 
-        if (sim_type == SV)
+        if (sim_type == SimType::SV)
             gI.gm_real[0] = gI.gm_real[3] = 1; // set I for SV
         else
             gI.gm_real[0] = gI.gm_real[5] = gI.gm_real[10] = gI.gm_real[15] = 1; // set I for DM
@@ -575,6 +572,7 @@ namespace NWQSim
         return fused_circuit;
     }
 
+    inline
     std::vector<SVGate> fuse_circuit_sv(std::shared_ptr<NWQSim::Circuit> circuit)
     {
         std::vector<SVGate> gates = GateFactory::getInstance().getSVGates(circuit->get_gates());
@@ -585,9 +583,9 @@ namespace NWQSim
         }
         IdxType n_qubits = circuit->num_qubits();
 
-        return fuse_circuit_gates(gates, n_qubits, SV);
+        return fuse_circuit_gates(gates, n_qubits, SimType::SV);
     }
-
+    inline
     std::vector<DMGate> fuse_circuit_dm(std::shared_ptr<NWQSim::Circuit> circuit)
     {
         std::vector<DMGate> gates = getDMGates(circuit->get_gates(), circuit->num_qubits());
@@ -601,8 +599,8 @@ namespace NWQSim
         std::vector<DMGate> tmp1_circuit;
         std::vector<DMGate> fused_circuit;
 
-        gate_fusion_1q(gates, tmp1_circuit, n_qubits, DM);
-        gate_fusion_2q(tmp1_circuit, fused_circuit, n_qubits, DM);
+        gate_fusion_1q(gates, tmp1_circuit, n_qubits, SimType::DM);
+        gate_fusion_2q(tmp1_circuit, fused_circuit, n_qubits, SimType::DM);
 
         return fused_circuit;
     }

--- a/include/dmsim/dm_cpu.hpp
+++ b/include/dmsim/dm_cpu.hpp
@@ -11,8 +11,7 @@
 #include "../private/macros.hpp"
 #include "../private/sim_gate.hpp"
 
-#include "../private/gate_factory/dm_gates.hpp"
-
+#include <memory>
 #include <random>
 #include <cstring>
 #include <algorithm>
@@ -25,7 +24,7 @@ namespace NWQSim
     {
 
     public:
-        DM_CPU(IdxType _n_qubits) : QuantumState(_n_qubits)
+        DM_CPU(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::DM)
         {
             // Initialize CPU side
             n_qubits = _n_qubits;
@@ -170,6 +169,64 @@ namespace NWQSim
                 printf("\n");
             }
         }
+        
+        virtual ValType *get_real() const override {return dm_real;};
+        virtual ValType *get_imag() const override {return dm_imag;};
+
+        virtual ValType fidelity(std::shared_ptr<QuantumState> other) override {
+            ValType result_real = 0;
+            ValType result_imag = 0;
+            const IdxType block_size = 32;
+            IdxType vector_dim = 1 << n_qubits;
+            double* sv_real = other->get_real();
+            double* sv_imag = other->get_imag();
+            IdxType i = 0;
+            if (block_size > vector_dim)
+                goto EPILOGUE;
+            for (i = 0; i < vector_dim && block_size <= vector_dim; i+=block_size) {
+                // $\bra{\psi}$: vector in dual space
+                double* block_bra_real = sv_real + i;
+                double* block_bra_imag = sv_imag + i;
+                // individual block
+                for (IdxType j = 0; j < vector_dim; j += block_size) {
+                    // $\ket{\psi}$: vector in primal space
+                    double* block_ket_real = sv_real + i;
+                    double* block_ket_imag = sv_imag + i;
+                    // $\rho$: density matrix
+                    double* block_dm_real = dm_real + i * vector_dim + j;
+                    double* block_dm_imag = dm_real + i * vector_dim + j;
+                    #pragma unroll
+                    for (IdxType k = i * block_size; k < block_size; k++) {
+                        ValType a = block_bra_real[k];
+                        ValType b = -block_bra_imag[k];
+                        #pragma unroll
+                        for (IdxType r = j * block_size; r < block_size; r++) {
+                            ValType c = block_dm_real[k * vector_dim + r];
+                            ValType d = block_dm_imag[k * vector_dim + r];
+                            ValType g = block_ket_real[r];
+                            ValType f = block_ket_imag[r];
+                            result_real += a * c * g - a * d * f - b * c * f - b * d * g;
+                            result_imag += a * c * f + a * d * g + b * c * g - b * d * f;
+                        }
+                    }
+                }
+            }
+            EPILOGUE:
+            for (IdxType ind = i; ind < vector_dim; ind++) {
+                ValType a = sv_real[ind];
+                ValType b = -sv_imag[ind];
+                for (IdxType j = 0; j < vector_dim; j ++) {
+                    ValType c = dm_real[ind * vector_dim + j];
+                    ValType d = dm_imag[ind * vector_dim + j];
+                    ValType g = sv_real[j];
+                    ValType f = sv_real[j];
+                    result_real += a * c * g - a * d * f - b * c * f - b * d * g;
+                    result_imag += a * c * f + a * d * g + b * c * g - b * d * f;
+                }
+            }
+            assert(abs(result_imag) <= 1e-10);
+            return result_real;
+        };
     protected:
         // n_qubits is the number of qubits
         IdxType n_qubits;

--- a/include/dmsim/dm_cpu.hpp
+++ b/include/dmsim/dm_cpu.hpp
@@ -180,46 +180,50 @@ namespace NWQSim
             IdxType vector_dim = 1 << n_qubits;
             double* sv_real = other->get_real();
             double* sv_imag = other->get_imag();
-            IdxType i = 0;
-            if (block_size > vector_dim)
-                goto EPILOGUE;
-            for (i = 0; i < vector_dim && block_size <= vector_dim; i+=block_size) {
-                // $\bra{\psi}$: vector in dual space
-                double* block_bra_real = sv_real + i;
-                double* block_bra_imag = sv_imag + i;
-                // individual block
-                for (IdxType j = 0; j < vector_dim; j += block_size) {
-                    // $\ket{\psi}$: vector in primal space
-                    double* block_ket_real = sv_real + i;
-                    double* block_ket_imag = sv_imag + i;
-                    // $\rho$: density matrix
-                    double* block_dm_real = dm_real + i * vector_dim + j;
-                    double* block_dm_imag = dm_real + i * vector_dim + j;
-                    #pragma unroll
-                    for (IdxType k = i * block_size; k < block_size; k++) {
-                        ValType a = block_bra_real[k];
-                        ValType b = -block_bra_imag[k];
-                        #pragma unroll
-                        for (IdxType r = j * block_size; r < block_size; r++) {
-                            ValType c = block_dm_real[k * vector_dim + r];
-                            ValType d = block_dm_imag[k * vector_dim + r];
-                            ValType g = block_ket_real[r];
-                            ValType f = block_ket_imag[r];
-                            result_real += a * c * g - a * d * f - b * c * f - b * d * g;
-                            result_imag += a * c * f + a * d * g + b * c * g - b * d * f;
-                        }
-                    }
-                }
-            }
-            EPILOGUE:
-            for (IdxType ind = i; ind < vector_dim; ind++) {
+            // IdxType i = 0;
+            // IdxType outer_limit = (vector_dim / block_size) * block_size;
+            // if (block_size > vector_dim)
+            //     goto EPILOGUE;
+            // for (i = 0; i < outer_limit; i+=block_size) {
+            //     // $\bra{\psi}$: vector in dual space
+            //     double* block_ket_real = sv_real + i;
+            //     double* block_ket_imag = sv_imag + i;
+
+            // #pragma unroll
+            // for (IdxType k = i; k < i + block_size; k++) {
+            //     ValType a = block_ket_real[k];
+            //     ValType b = block_ket_imag[k];
+            //     // individual block
+            //     for (IdxType j = 0; j < outer_limit; j += block_size) {
+            //         // $\ket{\psi}$: vector in primal space
+            //         double* block_bra_real = sv_real + j;
+            //         double* block_bra_imag = sv_imag + j;
+            //         // $\rho$: density matrix
+            //         double* block_dm_real = dm_real + i * vector_dim + j;
+            //         double* block_dm_imag = dm_imag + i * vector_dim + j;
+            //             #pragma unroll
+            //             for (IdxType r = j; r < j + block_size; r++) {
+            //                 printf("%d %d\n", k, r);
+            //                 ValType c = block_dm_real[k * vector_dim + r];
+            //                 ValType d = block_dm_imag[k * vector_dim + r];
+            //                 ValType g = block_bra_real[r];
+            //                 ValType f = -block_bra_imag[r];
+            //                 result_real += a * c * g - a * d * f - b * c * f - b * d * g;
+            //                 result_imag += a * c * f + a * d * g + b * c * g - b * d * f;
+            //             }
+            //         }
+            //     }
+            // }
+
+            // EPILOGUE:
+            for (IdxType ind = 0; ind < vector_dim; ind++) {
                 ValType a = sv_real[ind];
                 ValType b = -sv_imag[ind];
                 for (IdxType j = 0; j < vector_dim; j ++) {
                     ValType c = dm_real[ind * vector_dim + j];
                     ValType d = dm_imag[ind * vector_dim + j];
                     ValType g = sv_real[j];
-                    ValType f = sv_real[j];
+                    ValType f = sv_imag[j];
                     result_real += a * c * g - a * d * f - b * c * f - b * d * g;
                     result_imag += a * c * f + a * d * g + b * c * g - b * d * f;
                 }

--- a/include/dmsim/dm_cuda_mpi.cuh
+++ b/include/dmsim/dm_cuda_mpi.cuh
@@ -44,7 +44,7 @@ namespace NWQSim
     class DM_CUDA_MPI : public QuantumState
     {
     public:
-        DM_CUDA_MPI(IdxType _n_qubits) : QuantumState(_n_qubits)
+        DM_CUDA_MPI(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::DM)
         {
             // Initialize the GPU
             n_qubits = _n_qubits;
@@ -900,6 +900,8 @@ namespace NWQSim
                 grid.sync();
             }
         }
+        virtual ValType *get_real() const override {return dm_real;};
+        virtual ValType *get_imag() const override {return dm_imag;};
 
         __device__ __inline__ IdxType get_term(IdxType idx, IdxType p, IdxType q, IdxType r, IdxType s)
         {

--- a/include/dmsim/dm_hip.hpp
+++ b/include/dmsim/dm_hip.hpp
@@ -43,7 +43,7 @@ namespace NWQSim
     class DM_HIP : public QuantumState
     {
     public:
-        DM_HIP(IdxType _n_qubits) : QuantumState(_n_qubits)
+        DM_HIP(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::DM)
         {
             // Initialize the GPU
             n_qubits = _n_qubits;
@@ -123,6 +123,8 @@ namespace NWQSim
         {
             rng.seed(seed);
         }
+        virtual ValType *get_real() const override {return dm_real;};
+        virtual ValType *get_imag() const override {return dm_imag;};
 
         void sim(std::shared_ptr<NWQSim::Circuit> circuit) override
         {

--- a/include/nwq_util.hpp
+++ b/include/nwq_util.hpp
@@ -30,7 +30,11 @@ namespace NWQSim
     using IdxType = long long int;
     /* Basic data type for value */
     using ValType = double;
-
+    enum class SimType
+    {
+        SV,
+        DM
+    };
     inline std::string formatDuration(std::chrono::seconds input_seconds)
     {
         using namespace std::chrono;

--- a/include/private/config.hpp
+++ b/include/private/config.hpp
@@ -12,7 +12,9 @@ namespace NWQSim::Config
     inline bool ENABLE_NOISE = false;
     inline bool ENABLE_FUSION = true;
     inline bool ENABLE_TENSOR_CORE = false;
-
+    inline bool DEVICE_READ = false;
+    using IdxType = long long;
+    using ValType = double;
     inline std::string DEVICE_CONFIG_PATH = "~/NWQ-Sim/data/device/";
     inline std::string DEVICE_CONFIG_FILE = "dummy_ibmq12";
 
@@ -114,10 +116,24 @@ namespace NWQSim::Config
         backend_config = nlohmann::json::parse(f);
     }
 
+    /**
+     * @brief Read json file that stores backend noise properties from input path. Output from the function in the python script device_config.py
+     *        See an example usage in backedn_noise_validation.cpp
+     *
+     * @param path the absolute path path where json file locates. e.g., "./Data/"
+     */
+    inline void readDeviceConfig(const std::string& path) {
+        std::ifstream f(path);
+        if (f.fail())
+            throw std::logic_error("Device config file not found at " + path);
+        backend_config = nlohmann::json::parse(f);
+        DEVICE_READ = true;
+    }
+
     inline void Load(const std::string &filename = "../default_config.json")
     {
         LoadConfigFromFile(filename, true);
-        if (ENABLE_NOISE)
+        if (ENABLE_NOISE && !DEVICE_READ)
             readConfigFile();
     }
 
@@ -125,7 +141,7 @@ namespace NWQSim::Config
     {
         LoadConfigFromFile(filename, false);
 
-        if (ENABLE_NOISE)
+        if (ENABLE_NOISE && !DEVICE_READ)
             readConfigFile();
     }
 

--- a/include/private/gate_factory/device_noise.hpp
+++ b/include/private/gate_factory/device_noise.hpp
@@ -29,6 +29,7 @@ namespace NWQSim
     std::vector<OP> gates2q{OP::CX};
 
     //================ Set gates =================
+    inline
     void set_X(std::complex<double> *res)
     {
         /******************************************
@@ -40,6 +41,7 @@ namespace NWQSim
                                                    {{1, 0}, {0, 0}}};
         std::copy(&x_gate[0][0], &x_gate[0][0] + 4, res);
     }
+    inline
     void set_ID(std::complex<double> *res)
     {
         /******************************************
@@ -50,6 +52,7 @@ namespace NWQSim
                                                     {{0, 0}, {1, 0}}};
         std::copy(&id_gate[0][0], &id_gate[0][0] + 4, res);
     }
+    inline
     void set_SX(std::complex<double> *res)
     {
         /******************************************
@@ -61,6 +64,7 @@ namespace NWQSim
                                                     {std::complex<double>(0.5, -0.5), std::complex<double>(0.5, 0.5)}};
         std::copy(&sx_gate[0][0], &sx_gate[0][0] + 4, res);
     }
+    inline
     void set_RZ(std::complex<double> *res, double theta)
     {
         /******************************************
@@ -73,6 +77,7 @@ namespace NWQSim
             {{0, 0}, {cos(theta / 2), sin(theta / 2)}}};
         std::copy(&rz_gate[0][0], &rz_gate[0][0] + 4, res);
     }
+    inline
     void set_CX(std::complex<double> *res)
     {
         /******************************************

--- a/include/private/gate_factory/dm_gates.hpp
+++ b/include/private/gate_factory/dm_gates.hpp
@@ -9,7 +9,7 @@
 
 namespace NWQSim
 {
-
+    inline
     std::vector<DMGate> getDMGates(const std::vector<Gate> &gates, const IdxType n_qubits)
     {
         std::vector<DMGate> sim_dm_gates;

--- a/include/private/gate_factory/noise_model.hpp
+++ b/include/private/gate_factory/noise_model.hpp
@@ -67,6 +67,7 @@ namespace NWQSim
     /**
      * Kronecker product with scalar multiplication (if necessary) between two square matrices, A \otimes B = res, where dim is the dimension of A and B
      */
+     inline
     void kronProd(std::complex<double> *A, std::complex<double> *B, double c, std::complex<double> *res, int dim)
     {
         int bigdim = dim * dim; // dimsion of res

--- a/include/state.hpp
+++ b/include/state.hpp
@@ -10,13 +10,15 @@
 #include <vector>
 #include <string>
 
+
+
 namespace NWQSim
 {
     // Base class
     class QuantumState
     {
     public:
-        QuantumState(IdxType _n_qubits)
+        QuantumState(IdxType _n_qubits, SimType _sim_type): sim_type(_sim_type)
         {
             Config::Load();
             registerGates();
@@ -35,10 +37,14 @@ namespace NWQSim
         virtual IdxType *get_results() = 0;
         virtual IdxType measure(IdxType qubit) = 0;
         virtual IdxType *measure_all(IdxType repetition) = 0;
+        virtual ValType *get_real() const = 0;
+        virtual ValType *get_imag() const = 0;
 
         virtual ValType get_exp_z() = 0;
         virtual ValType get_exp_z(const std::vector<size_t> &in_bits) = 0;
-
+        virtual ValType fidelity(std::shared_ptr<QuantumState> other) {
+            throw std::runtime_error("Fidelity computation not implemented");
+        };
         virtual void print_res_state() = 0;
 
         virtual void save_state()
@@ -62,8 +68,8 @@ namespace NWQSim
         }
 
         IdxType i_proc = 0; // process id
-
         ValType *buffer_state = nullptr;
+        SimType sim_type;
     };
 
 } // namespace NWQSim

--- a/include/svsim/sv_cpu.hpp
+++ b/include/svsim/sv_cpu.hpp
@@ -22,7 +22,7 @@ namespace NWQSim
     {
 
     public:
-        SV_CPU(IdxType _n_qubits) : QuantumState(_n_qubits)
+        SV_CPU(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::SV)
         {
             // Initialize CPU side
             n_qubits = _n_qubits;
@@ -513,6 +513,11 @@ namespace NWQSim
                 printf("Purity Check fails after Gate-%lld=>%s(ctrl:%lld,qubit:%lld) with %lf\n", t, OP_NAMES[g.op_name], g.ctrl, g.qubit, purity);
             }
         }
+
+    
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
+
     };
 
 } // namespace NWQSim

--- a/include/svsim/sv_cuda.cuh
+++ b/include/svsim/sv_cuda.cuh
@@ -36,7 +36,7 @@ namespace NWQSim
     class SV_CUDA : public QuantumState
     {
     public:
-        SV_CUDA(IdxType _n_qubits) : QuantumState(_n_qubits)
+        SV_CUDA(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::SV)
         {
             // Initialize the GPU
             n_qubits = _n_qubits;
@@ -752,6 +752,8 @@ namespace NWQSim
             }
             grid.sync();
         }
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     }
 
 } // namespace NWQSim

--- a/include/svsim/sv_cuda.cuh
+++ b/include/svsim/sv_cuda.cuh
@@ -711,6 +711,9 @@ namespace NWQSim
             }
             BARR;
         }
+
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     };
 
     __global__ void simulation_kernel_cuda(SV_CUDA *sv_gpu, IdxType n_gates)
@@ -752,8 +755,6 @@ namespace NWQSim
             }
             grid.sync();
         }
-        virtual ValType *get_real() const override {return sv_real;};
-        virtual ValType *get_imag() const override {return sv_imag;};
     }
 
 } // namespace NWQSim

--- a/include/svsim/sv_cuda_mpi.cuh
+++ b/include/svsim/sv_cuda_mpi.cuh
@@ -40,7 +40,7 @@ namespace NWQSim
     class SV_CUDA_MPI : public QuantumState
     {
     public:
-        SV_CUDA_MPI(IdxType _n_qubits) : QuantumState(_n_qubits)
+        SV_CUDA_MPI(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::SV)
         {
             // Initialize the GPU
             n_qubits = _n_qubits;
@@ -1314,5 +1314,7 @@ namespace NWQSim
             }
             grid.sync();
         }
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     }
 }

--- a/include/svsim/sv_hip.hpp
+++ b/include/svsim/sv_hip.hpp
@@ -35,7 +35,7 @@ namespace NWQSim
     class SV_HIP : public QuantumState
     {
     public:
-        SV_HIP(IdxType _n_qubits) : QuantumState(_n_qubits)
+        SV_HIP(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::SV)
         {
             // Initialize the GPU
             n_qubits = _n_qubits;
@@ -713,6 +713,8 @@ namespace NWQSim
             }
             grid.sync();
         }
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     }
 
 } // namespace NWQSim

--- a/include/svsim/sv_mpi.hpp
+++ b/include/svsim/sv_mpi.hpp
@@ -23,7 +23,7 @@ namespace NWQSim
     {
 
     public:
-        SV_MPI(IdxType _n_qubits) : QuantumState(_n_qubits)
+        SV_MPI(IdxType _n_qubits) : QuantumState(_n_qubits, SimType::SV)
         {
             // SV initialization
             n_qubits = _n_qubits;
@@ -871,6 +871,8 @@ namespace NWQSim
             }
             // BARR_MPI;
         }
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     };
 
 } // namespace NWQSim

--- a/include/svsim/sv_omp.hpp
+++ b/include/svsim/sv_omp.hpp
@@ -471,6 +471,8 @@ namespace NWQSim
             }
             BARR;
         }
+        virtual ValType *get_real() const override {return sv_real;};
+        virtual ValType *get_imag() const override {return sv_imag;};
     };
 
 } // namespace NWQSim

--- a/qasm/nwq_qasm.cpp
+++ b/qasm/nwq_qasm.cpp
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
             dm_state->print_config(simulation_method);
             map<string, IdxType> *counts_dm = parser.execute(dm_state, total_shots, print_metrics);
             ValType fidelity = dm_state->fidelity(sv_state);
-            BackendManager::safe_print("State Fidelity: %e", fidelity);
+            BackendManager::safe_print("State Fidelity: %e\n", fidelity);
         }
         
     }

--- a/qasm/nwq_qasm.cpp
+++ b/qasm/nwq_qasm.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 
 /********** UPDATE THE INCLUDE PATH FOR LOCAL HEADER FILE HERE ************/
+#include "private/config.hpp"
 #include "src/qasm_parser.hpp"
 #include "src/parser_util.hpp"
 /**************************************************************************/
@@ -24,6 +25,7 @@ int main(int argc, char **argv)
     IdxType total_shots = 1024;
     bool run_with_basis = false;
     bool print_metrics = false;
+    bool report_fidelity = false;
     std::string backend = "CPU";
     std::string simulation_method = "sv";
 
@@ -47,6 +49,8 @@ int main(int argc, char **argv)
                   << "Runs the testing benchmarks for the specific index provided." << std::endl;
         std::cout << std::setw(20) << "-a"
                   << "Runs all testing benchmarks." << std::endl;
+        std::cout << std::setw(20) << "-device"
+                  << "Path to device model JSON." << std::endl;
         std::cout << std::setw(20) << "-backend_list"
                   << "Lists all the available backends." << std::endl;
         std::cout << std::setw(20) << "-metrics"
@@ -59,6 +63,8 @@ int main(int argc, char **argv)
                   << "Select the simulation method: sv (state vector, default), dm (density matrix). (default: " << simulation_method << ")." << std::endl;
         std::cout << std::setw(20) << "-basis"
                   << "Run the transpiled benchmark circuits which only contain basis gates." << std::endl;
+        std::cout << std::setw(20) << "-fidelity"
+                  << "Run both DM-Sim and SV-Sim and report the state fidelity." << std::endl;
     }
     if (cmdOptionExists(argv, argv + argc, "-shots"))
     {
@@ -81,9 +87,18 @@ int main(int argc, char **argv)
     {
         backend = std::string(getCmdOption(argv, argv + argc, "-backend"));
     }
+    if (cmdOptionExists(argv, argv + argc, "-device"))
+    {
+        std::string device = std::string(getCmdOption(argv, argv + argc, "-device"));
+        Config::readDeviceConfig(device);
+    }
     if (cmdOptionExists(argv, argv + argc, "-sim"))
     {
         simulation_method = std::string(getCmdOption(argv, argv + argc, "-sim"));
+    }
+    if (cmdOptionExists(argv, argv + argc, "-fidelity"))
+    {
+        report_fidelity = true;
     }
 // If MPI or NVSHMEM backend, initialize MPI
 #ifdef MPI_ENABLED
@@ -97,39 +112,65 @@ int main(int argc, char **argv)
         const char *filename = getCmdOption(argv, argv + argc, "-q");
         qasm_parser parser;
         parser.load_qasm_file(filename);
+        
+        if (!report_fidelity) {
+            // Create the backend
+            std::shared_ptr<NWQSim::QuantumState> state = BackendManager::create_state(backend, parser.num_qubits(), simulation_method);
+            if (!state)
+            {
+                std::cerr << "Failed to create backend\n";
+                return 1;
+            }
+            state->print_config(simulation_method);
+            map<string, IdxType> *counts = parser.execute(state, total_shots, print_metrics);
 
-        // Create the backend
-        std::shared_ptr<NWQSim::QuantumState> state = BackendManager::create_state(backend, parser.num_qubits(), simulation_method);
-        if (!state)
-        {
-            std::cerr << "Failed to create backend\n";
-            return 1;
+            // std::vector<size_t> in_bits;
+
+            // for (int i = 0; i < parser.num_qubits(); ++i)
+            // {
+            //     in_bits.push_back(i);
+            // }
+
+            // ValType exp_val_z = state->get_exp_z(in_bits);
+            // ValType exp_val_z_all = state->get_exp_z();
+            // for (size_t i = 0; i < parser.num_qubits(); ++i)
+            // {
+            //     in_bits[i] = i;
+            // }
+
+            if (state->i_proc == 0)
+            {
+                print_counts(counts, total_shots);
+                // fflush(stdout);
+                // printf("exp-val-z: %f\n", exp_val_z);
+                // printf("exp-val-z all: %f\n", exp_val_z_all);
+            }
+            delete counts;
+        } else {
+            
+            BackendManager::safe_print("Starting Statevector Simulation...");
+            std::shared_ptr<NWQSim::QuantumState> sv_state = BackendManager::create_state(backend, parser.num_qubits(), "sv");
+            if (!sv_state)
+            {
+                std::cerr << "Failed to create backend\n";
+                return 1;
+            }
+            sv_state->print_config(simulation_method);
+            map<string, IdxType> *counts_sv = parser.execute(sv_state, total_shots, print_metrics);
+
+            BackendManager::safe_print("Starting Density Matrix Simulation...");
+            std::shared_ptr<NWQSim::QuantumState> dm_state = BackendManager::create_state(backend, parser.num_qubits(), "dm");
+            if (!dm_state)
+            {
+                std::cerr << "Failed to create backend\n";
+                return 1;
+            }
+            dm_state->print_config(simulation_method);
+            map<string, IdxType> *counts_dm = parser.execute(dm_state, total_shots, print_metrics);
+            ValType fidelity = dm_state->fidelity(sv_state);
+            BackendManager::safe_print("State Fidelity: %e", fidelity);
         }
-        state->print_config(simulation_method);
-        map<string, IdxType> *counts = parser.execute(state, total_shots, print_metrics);
-
-        // std::vector<size_t> in_bits;
-
-        // for (int i = 0; i < parser.num_qubits(); ++i)
-        // {
-        //     in_bits.push_back(i);
-        // }
-
-        // ValType exp_val_z = state->get_exp_z(in_bits);
-        // ValType exp_val_z_all = state->get_exp_z();
-        // for (size_t i = 0; i < parser.num_qubits(); ++i)
-        // {
-        //     in_bits[i] = i;
-        // }
-
-        if (state->i_proc == 0)
-        {
-            print_counts(counts, total_shots);
-            // fflush(stdout);
-            // printf("exp-val-z: %f\n", exp_val_z);
-            // printf("exp-val-z all: %f\n", exp_val_z_all);
-        }
-        delete counts;
+        
     }
     if (cmdOptionExists(argv, argv + argc, "-qs"))
     {

--- a/vqe/include/observable/hamiltonian.hpp
+++ b/vqe/include/observable/hamiltonian.hpp
@@ -6,7 +6,6 @@
 #include "observable/pauli_operator.hpp"
 #include "transform/transform.hpp"
 #include "utils.hpp" 
-#include "state.hpp" 
 
 
 namespace NWQSim {

--- a/xacc/nwq_accelerator.cpp
+++ b/xacc/nwq_accelerator.cpp
@@ -7,7 +7,6 @@
 #include "AllGateVisitor.hpp"
 
 #include "nwq_accelerator.hpp"
-#include "../include/state.hpp"
 #include "../include/circuit.hpp"
 #include "../include/backendManager.hpp"
 #include "../include/nwq_util.hpp"

--- a/xacc/nwq_accelerator.hpp
+++ b/xacc/nwq_accelerator.hpp
@@ -48,7 +48,6 @@ namespace xacc
             std::string backend_name = "nvgpu";
             std::string simulation_type = "sv";
             bool vqe_mode = false;
-
             std::shared_ptr<NWQSim::QuantumState> m_state;
         };
 


### PR DESCRIPTION
Works with CPU, CUDA, and CUDA_MPI backends. Feature is enabled on command line with `-fidelity`. 

Allows for device JSON specification via the `-device` flag. 